### PR TITLE
fix: [sc-493] fix incorrect forced seconds regeneration

### DIFF
--- a/Sources/Frostflake/Frostflake.swift
+++ b/Sources/Frostflake/Frostflake.swift
@@ -108,7 +108,11 @@ public final class Frostflake {
             seconds = currentSecond
             sequenceNumber = 1
         } else if (sequenceNumber % forcedSecondRegenerationInterval) == 0 {
-            seconds = currentSecondsSinceEpoch()
+            let currentSecond = currentSecondsSinceEpoch()
+            if currentSecond > seconds {
+                seconds = currentSecond
+                sequenceNumber = 1
+            }
         }
 
         var returnValue = UInt64(seconds) << 32

--- a/Tests/FrostflakeTests/FrostflakeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeTests.swift
@@ -108,4 +108,16 @@ final class FrostflakeTests: XCTestCase {
             blackHole(Frostflake.generate())
         }
     }
+
+    // Regression test for sc-493
+    func testIncorrectForcingSecondRegenerationInterval() {
+        let frostflakeFactory = Frostflake(generatorIdentifier: UInt16(100))
+        for _ in 1 ..< 1_000_000 {
+            blackHole(frostflakeFactory.generate())
+        }
+        sleep(1)
+        for _ in 1 ..< 1_000_000 {
+            blackHole(frostflakeFactory.generate())
+        }
+    }
 }


### PR DESCRIPTION
## Description

There is an issue with high intense id generation.

Every 1_000 ids frostflake bumps a seconds counter, but do not reset a sequence number. That mean if sequence number is about to max (2^20), for example, 1M and actually the current second is just started, like hh:mm:ss.0000001, then we generator is capped to generate 2^20 - 1M = ~48k in the next second. In worst case it can be capped to 576 identifiers in the next second.