### PR TITLE
fix: Fix debug output

### DIFF
--- a/Sources/Frostflake/Frostflake.swift
+++ b/Sources/Frostflake/Frostflake.swift
@@ -58,6 +58,7 @@ public final class Frostflake {
     }
 
     // instance functions
+    // swiftlint:disable line_length
 
     /// Initialize the ``Frostflake`` class
     /// Creates an instance of the generator for a given unique generator id.
@@ -71,7 +72,6 @@ public final class Frostflake {
     ///   - concurrentAccess: Specifies whether the generator can be accessed from multiple
     ///   tasks/threads concurrently - if the generator is **only** used from a synchronized state
     ///   like .eg. an Actor context, you can specify false here to avoid the internal locking overhead
-    // swiftlint:disable line_length
     @inlinable
     public init(generatorIdentifier: UInt16,
                 forcedTimeRegenerationInterval: UInt32 = defaultForcedTimeRegenerationInterval,

--- a/Sources/Frostflake/FrostflakeHelpers.swift
+++ b/Sources/Frostflake/FrostflakeHelpers.swift
@@ -17,8 +17,18 @@ internal func currentSecondsSinceEpoch() -> UInt32 {
     return UInt32(timestamp.secondsSinceEpoch())
 }
 
+private extension String {
+    func pad(_ padding: Int = 2) -> String {
+        let toPad = padding - count
+        if toPad < 1 {
+            return self
+        }
+        return "".padding(toLength: toPad, withPad: "0", startingAt: 0) + self
+    }
+}
+
 /// Pretty printer for frostflakes for debugging
-public extension UInt64 {
+public extension FrostflakeIdentifier {
     func frostflakeDescription() -> String {
         let seconds = self >> Frostflake.secondsBits
         let sequenceNumber = (self & 0xFFFF_FFFF) >> Frostflake.generatorIdentifierBits
@@ -28,7 +38,8 @@ public extension UInt64 {
         time.convert(timestamp: Int(seconds))
 
         return """
-        (\(time.year)-\(time.month)-\(time.day) \(time.hour):\(time.minute):\(time.second) UTC\
+        \(self) (\(time.year)-\(String(time.month).pad())-\(String(time.day).pad()) \
+        \(String(time.hour).pad()):\(String(time.minute).pad()):\(String(time.second).pad()) UTC\
         , sequenceNumber:\(sequenceNumber), generatorIdentifier:\(generatorIdentifier))
         """
     }


### PR DESCRIPTION
## Description

Added zero padding to date/time output for frost flake debug descriptions.

## How Has This Been Tested?

Manually verified.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
