### PR TITLE
feat(minor): Add support for more convenient FrostflakeIdentifier() init

### DIFF
--- a/Benchmarks/Benchmark/FrostflakeBenchmark.swift
+++ b/Benchmarks/Benchmark/FrostflakeBenchmark.swift
@@ -52,24 +52,23 @@ let benchmarks = {
     // Limited to max 1M or we'll hit the max threshold here...
     Benchmark("Frostflake shared generator",
               configuration: .init(
-                warmupIterations: 0,
-                scalingFactor: .kilo,
-                maxIterations: .kilo(1)
+                  warmupIterations: 0,
+                  scalingFactor: .kilo,
+                  maxIterations: .kilo(1)
               )) { benchmark in
-                  for _ in benchmark.scaledIterations {
-                      Benchmark.blackHole(Frostflake.generate())
-                  }
-              }
+        for _ in benchmark.scaledIterations {
+            Benchmark.blackHole(Frostflake.generate())
+        }
+    }
 
     Benchmark("Frostflake shared generator with FrostflakeIdentifier() convenience",
               configuration: .init(
-                warmupIterations: 0,
-                scalingFactor: .kilo,
-                maxIterations: .kilo(1)
+                  warmupIterations: 0,
+                  scalingFactor: .kilo,
+                  maxIterations: .kilo(1)
               )) { benchmark in
-                  for _ in benchmark.scaledIterations {
-                      Benchmark.blackHole(FrostflakeIdentifier())
-                  }
-              }
-
+        for _ in benchmark.scaledIterations {
+            Benchmark.blackHole(FrostflakeIdentifier())
+        }
+    }
 }

--- a/Benchmarks/Benchmark/FrostflakeBenchmark.swift
+++ b/Benchmarks/Benchmark/FrostflakeBenchmark.swift
@@ -52,12 +52,24 @@ let benchmarks = {
     // Limited to max 1M or we'll hit the max threshold here...
     Benchmark("Frostflake shared generator",
               configuration: .init(
-                  warmupIterations: 0,
-                  scalingFactor: .kilo,
-                  maxIterations: .kilo(1)
+                warmupIterations: 0,
+                scalingFactor: .kilo,
+                maxIterations: .kilo(1)
               )) { benchmark in
-        for _ in benchmark.scaledIterations {
-            Benchmark.blackHole(Frostflake.generate())
-        }
-    }
+                  for _ in benchmark.scaledIterations {
+                      Benchmark.blackHole(Frostflake.generate())
+                  }
+              }
+
+    Benchmark("Frostflake shared generator with FrostflakeIdentifier() convenience",
+              configuration: .init(
+                warmupIterations: 0,
+                scalingFactor: .kilo,
+                maxIterations: .kilo(1)
+              )) { benchmark in
+                  for _ in benchmark.scaledIterations {
+                      Benchmark.blackHole(FrostflakeIdentifier())
+                  }
+              }
+
 }

--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ func testFrostflake() {
 
 There's also an optional shared class generator (which gives approx. 1/2 the performance):
 ```swift
-Frostflake.setup(generatorIdentifier: 1)
-let frostflake1 =  Frostflake.generate()
-let frostflake2 =  Frostflake.generate()
+Frostflake.setup(generatorIdentifier: 1) // Must always be set up once, globally shared
+ let frostflake1 =  FrostflakeIdentifier()
+ let frostflake2 =  FrostflakeIdentifier()
+ // Or optionally:
+ let frostflake3 =  Frostflake.generate()
+ let frostflake4 =  Frostflake.generate()
 ```
 # Implementation notes
 The Frostflake is a 64-bit value just like Snowflake, but the bit allocation differs a little bit. 

--- a/Sources/Frostflake/Frostflake.swift
+++ b/Sources/Frostflake/Frostflake.swift
@@ -43,13 +43,15 @@ public final class Frostflake {
 
     /// Convenience static variable when using the same generator in many places
     /// The global generator identifier **must** be set using `setup(generatorIdentifier:)` before accessing
-    /// this shared generator of we'll fatalError().
+    /// this shared generator of we'll fatalError(). This includes by creating `FrostflakeIdentifier()` instances too
+    /// which uses this shared generator in the implementation.
     ///
     ///  Sample usage:
     ///  ```swift
     /// Frostflake.setup(generatorIdentifier: 1)
     /// let frostflake1 =  Frostflake.generate()
     /// let frostflake2 =  Frostflake.generate()
+    /// let frostflake3 = FrostflakeIdentifier()
     ///  ```
     @inlinable
     @inline(__always)
@@ -58,7 +60,6 @@ public final class Frostflake {
     }
 
     // instance functions
-    // swiftlint:disable line_length
 
     /// Initialize the ``Frostflake`` class
     /// Creates an instance of the generator for a given unique generator id.

--- a/Sources/Frostflake/FrostflakeDefinitions.swift
+++ b/Sources/Frostflake/FrostflakeDefinitions.swift
@@ -10,6 +10,8 @@
 public typealias FrostflakeIdentifier = UInt64
 
 public extension FrostflakeIdentifier {
+    @inlinable
+    @inline(__always)
     init() {
         self = Frostflake.sharedGenerator.generate()
     }

--- a/Sources/Frostflake/FrostflakeDefinitions.swift
+++ b/Sources/Frostflake/FrostflakeDefinitions.swift
@@ -6,9 +6,14 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// swiftlint:disable line_length
 /// Alias for Frostflake identifier type
 public typealias FrostflakeIdentifier = UInt64
+
+public extension FrostflakeIdentifier {
+    init() {
+        self = Frostflake.sharedGenerator.generate()
+    }
+}
 
 public extension Frostflake {
     /// Default number of bits allocated to seconds, default 32 bits, gives us ~136 years

--- a/Sources/FrostflakeUtility/FrostflakeUtility.swift
+++ b/Sources/FrostflakeUtility/FrostflakeUtility.swift
@@ -6,8 +6,6 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-// swiftlint:disable line_length
-
 import ArgumentParser
 import Frostflake
 

--- a/Tests/FrostflakeTests/FrostflakeNegativeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeNegativeTests.swift
@@ -33,8 +33,7 @@
             if idGenerated < Frostflake.allowedSequenceNumberRange.count {
                 throw XCTSkip("This host is pretty slow, only \(idGenerated) generated")
             }
-            XCTAssertNotEqual(exceptionBadInstruction, nil,
-                      "precondition on too many FrostFlake IDs per second was not triggered")
+            XCTAssertNotNil(exceptionBadInstruction, "precondition on too many FrostFlake IDs per second was not triggered")
         }
     }
 

--- a/Tests/FrostflakeTests/FrostflakeNegativeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeNegativeTests.swift
@@ -33,7 +33,7 @@
             if idGenerated < Frostflake.allowedSequenceNumberRange.count {
                 throw XCTSkip("This host is pretty slow, only \(idGenerated) generated")
             }
-            XCTAssert(exceptionBadInstruction != nil,
+            XCTAssertNotEqual(exceptionBadInstruction, nil,
                       "precondition on too many FrostFlake IDs per second was not triggered")
         }
     }

--- a/Tests/FrostflakeTests/FrostflakeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeTests.swift
@@ -14,6 +14,11 @@ import XCTest
 final class FrostflakeTests: XCTestCase {
     private let smallRangeTest = 1 ..< 1_000
 
+    override class func setUp() {
+        let frostflake = Frostflake(generatorIdentifier: 47)
+        Frostflake.setup(sharedGenerator: frostflake)
+    }
+
     // Verified using https://www.epochconverter.com as well manually
     func testUnixEpochConversion() {
         var unixEpoch = EpochDateTime.unixEpoch()
@@ -98,20 +103,12 @@ final class FrostflakeTests: XCTestCase {
     }
 
     func testFrostflakeSharedGenerator() {
-        let frostflake = Frostflake(generatorIdentifier: 47)
-
-        Frostflake.setup(sharedGenerator: frostflake)
-
         for _ in smallRangeTest {
             blackHole(Frostflake.generate())
         }
     }
 
     func testFrostflakeSharedGeneratorWithCustomInit() {
-        let frostflake = Frostflake(generatorIdentifier: 49)
-
-        Frostflake.setup(sharedGenerator: frostflake)
-
         for _ in smallRangeTest {
             blackHole(FrostflakeIdentifier())
         }

--- a/Tests/FrostflakeTests/FrostflakeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeTests.swift
@@ -107,6 +107,16 @@ final class FrostflakeTests: XCTestCase {
         }
     }
 
+    func testFrostflakeSharedGeneratorWithCustomInit() {
+        let frostflake = Frostflake(generatorIdentifier: 49)
+
+        Frostflake.setup(sharedGenerator: frostflake)
+
+        for _ in smallRangeTest {
+            blackHole(FrostflakeIdentifier())
+        }
+    }
+
     // Regression test for sc-493
     func testIncorrectForcingSecondRegenerationInterval() {
         let frostflakeFactory = Frostflake(generatorIdentifier: UInt16(100))


### PR DESCRIPTION
## Description

Allows for more convenient use sites when using the shared generator:

```swift
  Frostflake.setup(sharedGenerator: frostflake)
...
  let frostflake1 = FrostflakeIdentifier()
  let frostflake2 = FrostflakeIdentifier()
```

Performance is identical to using the shared generator, so this is the recommended way to get new frost flakes:


## How Has This Been Tested?

Manual and unit test, benchmark.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
