### PR TITLE
feat(major): [sc-2509] use lock-free for frostflake [suggestion]

### DIFF
--- a/Benchmarks/Benchmark/FrostflakeBenchmark.swift
+++ b/Benchmarks/Benchmark/FrostflakeBenchmark.swift
@@ -6,10 +6,14 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
+import Atomics
 import Benchmark
+import DateTime
 import Frostflake
 
 let benchmarks = {
+    var frostflakeFactory: Frostflake! // avoid locks optimizations
+
     // Once during runtime setup can be done before registering benchmarks
     Benchmark.defaultConfiguration = .init(warmupIterations: 5,
                                            scalingFactor: .mega,
@@ -18,6 +22,7 @@ let benchmarks = {
 
     Benchmark("Frostflake with locks") { benchmark in
         let frostflakeFactory = Frostflake(generatorIdentifier: UInt16(benchmark.currentIteration),
+                                           forcedTimeRegenerationInterval: 0,
                                            concurrentAccess: true)
 
         benchmark.startMeasurement()
@@ -27,8 +32,8 @@ let benchmarks = {
     }
 
     Benchmark("Frostflake without locks") { benchmark in
-        let frostflakeFactory = Frostflake(generatorIdentifier: UInt16(benchmark.currentIteration),
-                                           concurrentAccess: false)
+        frostflakeFactory = Frostflake(generatorIdentifier: UInt16(benchmark.currentIteration),
+                                       concurrentAccess: false)
 
         benchmark.startMeasurement()
         for _ in benchmark.scaledIterations {
@@ -38,7 +43,7 @@ let benchmarks = {
 
     Benchmark("Frostflake descriptions",
               configuration: .init(scalingFactor: .kilo)) { benchmark in
-        let frostflakeFactory = Frostflake(generatorIdentifier: UInt16(benchmark.currentIteration))
+        frostflakeFactory = Frostflake(generatorIdentifier: UInt16(benchmark.currentIteration))
         for _ in benchmark.scaledIterations {
             let frostflake = frostflakeFactory.generate()
             let description = frostflake.frostflakeDescription()
@@ -69,6 +74,32 @@ let benchmarks = {
               )) { benchmark in
         for _ in benchmark.scaledIterations {
             Benchmark.blackHole(FrostflakeIdentifier())
+        }
+    }
+
+    // Limited to max 1M or we'll hit the max threshold here...
+    Benchmark("Frostflake shared generator (multitask)",
+              configuration: .init(
+                  warmupIterations: 0,
+                  scalingFactor: .kilo,
+                  maxIterations: .kilo(1)
+              )) { benchmark in
+
+        let ffIDs = await withTaskGroup(of: FrostflakeIdentifier.self) { group in
+            var ids = [FrostflakeIdentifier]()
+            for _ in benchmark.scaledIterations {
+                group.addTask {
+                    Frostflake.generate()
+                }
+            }
+            // grab movies as their tasks complete, and append them to the `movies` array
+            for await id in group {
+                ids.append(id)
+            }
+            return ids
+        }
+        for id in ffIDs {
+            Benchmark.blackHole(id)
         }
     }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "package-concurrency-helpers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-concurrency-helpers",
-      "state" : {
-        "revision" : "f3dde63a895dcea3edaab06eeb6487ef2fcbe635",
-        "version" : "0.0.11"
-      }
-    },
-    {
       "identity" : "package-datetime",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/package-datetime",
@@ -64,15 +55,6 @@
       }
     },
     {
-      "identity" : "package-latency-tools",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-latency-tools",
-      "state" : {
-        "revision" : "93d2be69c484bebb28c5192249d7e1da15236d34",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "progress.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/Progress.swift",
@@ -88,6 +70,15 @@
       "state" : {
         "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
         "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics",
+      "state" : {
+        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,10 +17,10 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(url: "https://github.com/apple/swift-atomics", .upToNextMajor(from: "1.1.0")),
         .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-system", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/ordo-one/package-concurrency-helpers", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "1.2.0")),
         .package(url: "https://github.com/ordo-one/package-datetime", .upToNextMajor(from: "0.0.1")),
         .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting", from: Version("2.0.0"))
@@ -29,7 +29,7 @@ let package = Package(
         // Main library target
         .target(name: "Frostflake",
                 dependencies: [
-                    .product(name: "ConcurrencyHelpers", package: "package-concurrency-helpers"),
+                    .product(name: "Atomics", package: "swift-atomics"),
                     .product(name: "DateTime", package: "package-datetime"),
                 ],
                 path: "Sources/Frostflake"),

--- a/Sources/Frostflake/FrostflakeHelpers.swift
+++ b/Sources/Frostflake/FrostflakeHelpers.swift
@@ -27,12 +27,27 @@ private extension String {
     }
 }
 
+/// Parts extration
+public extension FrostflakeIdentifier {
+    func frostflakeSeconds() -> UInt32 {
+        FrostflakeLayout.seconds(self)
+    }
+
+    func frostflakeGeneratorIdentifier() -> UInt16 {
+        FrostflakeLayout.generatorId(self)
+    }
+
+    func frostflakeSequenceNumber() -> UInt32 {
+        FrostflakeLayout.sequenceNumber(self)
+    }
+}
+
 /// Pretty printer for frostflakes for debugging
 public extension FrostflakeIdentifier {
     func frostflakeDescription() -> String {
-        let seconds = self >> Frostflake.secondsBits
-        let sequenceNumber = (self & 0xFFFF_FFFF) >> Frostflake.generatorIdentifierBits
-        let generatorIdentifier = (self & 0xFFFF_FFFF) & (0xFFFF_FFFF >> Frostflake.sequenceNumberBits)
+        let seconds = frostflakeSeconds()
+        let generatorIdentifier = frostflakeGeneratorIdentifier()
+        let sequenceNumber = frostflakeSequenceNumber()
 
         var time = EpochDateTime.unixEpoch()
         time.convert(timestamp: Int(seconds))

--- a/Tests/FrostflakeTests/FrostflakeNegativeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeNegativeTests.swift
@@ -6,7 +6,7 @@
 //
 // http://www.apache.org/licenses/LICENSE-2.0
 
-#if os(OSX)
+#if os(OSX) && DEBUG
 
     @testable import Frostflake
 
@@ -24,9 +24,9 @@
             let exceptionBadInstruction: BadInstructionException? = catchBadInstruction {
                 repeat {
                     for _ in Frostflake.allowedSequenceNumberRange {
-                        blackHole(frostflakeFactory.generate())
-                        blackHole(frostflakeFactory.generate())
                         idGenerated += 2
+                        blackHole(frostflakeFactory.generate())
+                        blackHole(frostflakeFactory.generate())
                     }
                 } while currentSecondsSinceEpoch() - testStarted <= 1
             }


### PR DESCRIPTION
## Description

1. Use Atomics instead of Lock to avoid outliers in Shared static generator
2. Change 64bit layout to <GeneratorId: 11><Seconds: 32><SeqNum: 21> (to this order) to replace pre-condition to assert
3. Add parts extraction to FrostflakeIdentifier

## How Has This Been Tested?

Shared generator put out of local scope to avoid Lock optimisation.
This improvement was tested locally on Mac M2 giving x1.5 performance on shared generator. Might be not applicable to Linux/x86.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
