### PR TITLE
fix(patch): [sc-2147] Allow for setting the same shared instance multiple times without crashing

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -10,9 +10,9 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../"),
-        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.13.0"),
-        //.package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
-        //.package(url: "https://github.com/apple/swift-system", from: "1.0.0")
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.13.0")
+        // .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
+        // .package(url: "https://github.com/apple/swift-system", from: "1.0.0")
     ],
     targets: [
         .executableTarget(
@@ -20,9 +20,9 @@ let package = Package(
             dependencies: [
                 .product(name: "Frostflake", package: "package-frostflake"),
                 .product(name: "Benchmark", package: "package-benchmark"),
-                .product(name: "BenchmarkPlugin", package: "package-benchmark"),
-                //.product(name: "ArgumentParser", package: "swift-argument-parser"),
-                //.product(name: "SystemPackage", package: "swift-system"),
+                .product(name: "BenchmarkPlugin", package: "package-benchmark")
+                // .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                // .product(name: "SystemPackage", package: "swift-system"),
             ],
             path: "Benchmarks/Frostflake"
         )

--- a/Sources/Frostflake/Frostflake.swift
+++ b/Sources/Frostflake/Frostflake.swift
@@ -31,6 +31,10 @@ public final class Frostflake {
 
     /// Setup may only be called a single time for a global shared generator identifier
     public static func setup(sharedGenerator: Frostflake) {
+        guard privateSharedGenerator !== sharedGenerator else { // To allow for better testing
+            return
+        }
+
         if privateSharedGenerator != nil {
             preconditionFailure("called setup multiple times")
         }

--- a/Sources/Frostflake/FrostflakeHelpers.swift
+++ b/Sources/Frostflake/FrostflakeHelpers.swift
@@ -12,7 +12,7 @@ import DateTime
 /// 32 bit number of seconds gives us ~136 years
 @inlinable
 @inline(__always)
-internal func currentSecondsSinceEpoch() -> UInt32 {
+func currentSecondsSinceEpoch() -> UInt32 {
     let timestamp = InternalUTCClock.now
     return UInt32(timestamp.seconds())
 }

--- a/Tests/FrostflakeTests/FrostflakeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeTests.swift
@@ -13,14 +13,14 @@ import XCTest
 
 final class FrostflakeTests: XCTestCase {
     private let smallRangeTest = 1 ..< 1_000
-    static let frostflake = Frostflake(generatorIdentifier: 47)
+    private static let frostflake = Frostflake(generatorIdentifier: 47)
 
     override class func setUp() {
         Frostflake.setup(sharedGenerator: frostflake)
     }
 
     func testMultipleSharedSetups() {
-        Frostflake.setup(sharedGenerator: FrostflakeTests.frostflake) // Tests that we can set up multiple times with exact same instance
+        Frostflake.setup(sharedGenerator: Self.frostflake) // Tests that we can set up multiple times with exact same instance
     }
 
     // Verified using https://www.epochconverter.com as well manually
@@ -50,7 +50,7 @@ final class FrostflakeTests: XCTestCase {
 
     func testTestEpochWithFutureDate() {
         var testEpoch = EpochDateTime.testEpoch()
-        testEpoch.convert(timestamp: 1653061201) // + 100 minutes
+        testEpoch.convert(timestamp: 1_653_061_201) // + 100 minutes
 
         // EpochDateTime(year: 2022, month: 5, day: 20, hour: 15, minute: 40, second: 1)
         XCTAssertEqual(testEpoch.year, 2_022)

--- a/Tests/FrostflakeTests/FrostflakeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeTests.swift
@@ -13,10 +13,14 @@ import XCTest
 
 final class FrostflakeTests: XCTestCase {
     private let smallRangeTest = 1 ..< 1_000
+    static let frostflake = Frostflake(generatorIdentifier: 47)
 
     override class func setUp() {
-        let frostflake = Frostflake(generatorIdentifier: 47)
         Frostflake.setup(sharedGenerator: frostflake)
+    }
+
+    func testMultipleSharedSetups() {
+        Frostflake.setup(sharedGenerator: FrostflakeTests.frostflake) // Tests that we can set up multiple times with exact same instance
     }
 
     // Verified using https://www.epochconverter.com as well manually


### PR DESCRIPTION
## Description

As requested for testing by @mr-swifter, we now don't bail out if setting the exact same instance for the shared case.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
