### PR TITLE
feat(minor): [sc-920] Support more human readable shorter frostflakes

### DIFF
--- a/Benchmarks/Benchmarks/Frostflake/FrostflakeBenchmark.swift
+++ b/Benchmarks/Benchmarks/Frostflake/FrostflakeBenchmark.swift
@@ -71,4 +71,26 @@ let benchmarks = {
             Benchmark.blackHole(FrostflakeIdentifier())
         }
     }
+    Benchmark("Frostflake base58Encoding",
+              configuration: .init(
+                warmupIterations: 0,
+                scalingFactor: .kilo,
+                maxIterations: .kilo(1)
+              )) { benchmark in
+      for _ in benchmark.scaledIterations {
+          Benchmark.blackHole(FrostflakeIdentifier().base58)
+      }
+    }
+
+    Benchmark("Frostflake base58Decoding",
+              configuration: .init(
+                warmupIterations: 0,
+                scalingFactor: .kilo,
+                maxIterations: .kilo(1)
+              )) { benchmark in
+      let base58String = FrostflakeIdentifier().base58
+      for _ in benchmark.scaledIterations {
+          Benchmark.blackHole(UInt64(base58: base58String))
+      }
+    }
 }

--- a/Benchmarks/Package.resolved
+++ b/Benchmarks/Package.resolved
@@ -1,30 +1,21 @@
 {
   "pins" : [
     {
+      "identity" : "hdrhistogram-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/HdrHistogram/hdrhistogram-swift",
+      "state" : {
+        "revision" : "a69fa24d7b70421870cafa86340ece900489e17e",
+        "version" : "0.1.2"
+      }
+    },
+    {
       "identity" : "package-benchmark",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ordo-one/package-benchmark.git",
       "state" : {
-        "revision" : "f629323bec4371d5cb03f33e297203d744745f20",
-        "version" : "1.13.0"
-      }
-    },
-    {
-      "identity" : "package-datetime",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-datetime",
-      "state" : {
-        "revision" : "d1242188c9f48aad297e6ca9b717776f8660bc31",
-        "version" : "1.0.2"
-      }
-    },
-    {
-      "identity" : "package-histogram",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/package-histogram",
-      "state" : {
-        "revision" : "a69fa24d7b70421870cafa86340ece900489e17e",
-        "version" : "0.1.2"
+        "revision" : "ddf6c1ae01e139120bcdb917ece52819ee69d47a",
+        "version" : "1.22.1"
       }
     },
     {
@@ -37,21 +28,12 @@
       }
     },
     {
-      "identity" : "progress.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ordo-one/Progress.swift",
-      "state" : {
-        "revision" : "29dc5dc29d8408f42878b832c7aae38a35ff26ee",
-        "version" : "1.0.3"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
-        "version" : "1.2.3"
+        "revision" : "c8ed701b513cf5177118a175d85fbbbcd707ab41",
+        "version" : "1.3.0"
       }
     },
     {
@@ -61,15 +43,6 @@
       "state" : {
         "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
         "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swift-extras-json",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swift-extras/swift-extras-json",
-      "state" : {
-        "revision" : "122b9454ef01bf89a4c190b8fd3717ddd0a2fbd0",
-        "version" : "0.6.0"
       }
     },
     {

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,11 +6,11 @@ import PackageDescription
 let package = Package(
     name: "Benchmarks",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v14)
     ],
     dependencies: [
         .package(path: "../"),
-        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.13.0"),
+        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.13.0")
     ],
     targets: [
         .executableTarget(
@@ -18,7 +18,7 @@ let package = Package(
             dependencies: [
                 .product(name: "FrostflakeKit", package: "package-frostflake"),
                 .product(name: "Benchmark", package: "package-benchmark"),
-                .product(name: "BenchmarkPlugin", package: "package-benchmark"),
+                .product(name: "BenchmarkPlugin", package: "package-benchmark")
             ],
             path: "Benchmarks/Frostflake"
         )

--- a/Sources/FrostflakeKit/FrostflakeIdentifier+Base58.swift
+++ b/Sources/FrostflakeKit/FrostflakeIdentifier+Base58.swift
@@ -1,0 +1,48 @@
+extension FrostflakeIdentifier {
+    private static let _base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    private static let _base58Characters = Array(_base58Alphabet) // Convert to array for direct indexing
+    // ASCII value of 'z' is 122, so we create an array of size 123.
+    private static let _base58AlphabetIndexByChar: [Int?] = {
+        var indexes = [Int?](repeating: nil, count: 123) // 'z' is the highest ASCII character in the alphabet.
+        for (index, char) in _base58Alphabet.utf8.enumerated() {
+            indexes[Int(char)] = index
+        }
+        return indexes
+    }()
+
+    public var base58: String {
+        var number = self
+        var encodedChars: [Character] = [] // Use array to collect characters
+
+        while number > 0 {
+            let remainder = Int(number % 58)
+            number /= 58
+            encodedChars.append(Self._base58Characters[remainder]) // Append character to the array
+        }
+
+        return String(encodedChars.reversed()) // Create a string from the reversed array of characters
+    }
+
+    // Base58 Decoding
+    public init? (base58: String) {
+        self = 0
+
+        for character in base58.utf8 {
+            guard character < Self._base58AlphabetIndexByChar.count, let index = Self._base58AlphabetIndexByChar[Int(character)] else {
+                return nil // Character not in Base58 alphabet or not a valid ASCII character
+            }
+
+            let (multiplied, overflowMult) = self.multipliedReportingOverflow(by: 58)
+            if overflowMult {
+                return nil // Overflow in multiplication
+            }
+
+            let (added, overflowAdd) = multiplied.addingReportingOverflow(UInt64(index))
+            if overflowAdd {
+                return nil // Overflow in addition
+            }
+
+            self = added
+        }
+    }
+}

--- a/Sources/FrostflakeUtility/FrostflakeUtility.swift
+++ b/Sources/FrostflakeUtility/FrostflakeUtility.swift
@@ -15,12 +15,23 @@ struct FrostflakeUtility: AsyncParsableCommand {
     var generatorIdentifier: Int = Frostflake.defaultManualGeneratorIdentifier
 
     @Option(help: "Decode a Frostflake timestamp by specifying a frostflake identifier")
-    var identifier: FrostflakeIdentifier?
+    var identifier: String?
+
+    @Flag(help: "Output Frostflake encoded in base58") var base58 = false
 
     mutating func run() async throws {
         if let frostflakeIdentifier = identifier {
-            print("Frostflake \(frostflakeIdentifier) decoded:")
-            print("\(frostflakeIdentifier.frostflakeDescription())")
+            if let value = UInt64(frostflakeIdentifier) {
+                print("Frostflake \(frostflakeIdentifier) decoded:")
+                print("\(value.frostflakeDescription())")
+            } else {
+                if let value = UInt64(base58: frostflakeIdentifier) {
+                    print("Frostflake \(frostflakeIdentifier) decoded:")
+                    print("\(value.frostflakeDescription())")
+                } else {
+                    print("Could not decode \(frostflakeIdentifier)")
+                }
+            }
         } else {
             guard Frostflake.validGeneratorIdentifierRange.contains(generatorIdentifier) else {
                 print("Frostflake generatorIdentifier should be in the range \(Frostflake.validGeneratorIdentifierRange)")
@@ -29,7 +40,11 @@ struct FrostflakeUtility: AsyncParsableCommand {
 
             let frostflakeFactory = Frostflake(generatorIdentifier: UInt16(generatorIdentifier),
                                                concurrentAccess: false)
-            print("\(frostflakeFactory.generate())")
+            if base58 {
+                print("\(frostflakeFactory.generate().base58)")
+            } else {
+                print("\(frostflakeFactory.generate())")
+            }
         }
     }
 }

--- a/Tests/FrostflakeTests/FrostflakeTests.swift
+++ b/Tests/FrostflakeTests/FrostflakeTests.swift
@@ -91,10 +91,26 @@ final class FrostflakeTests: XCTestCase {
         let frostflake = Frostflake(generatorIdentifier: 47)
         Frostflake.setup(sharedGenerator: frostflake)
     }
-    
+
     func testFrostflakeDescription() {
-        let frostflake: FrostflakeIdentifier = 7319193677673271295
-        XCTAssertEqual(frostflake.frostflakeDescription(), 
+        let frostflake: FrostflakeIdentifier = 7_319_193_677_673_271_295
+        XCTAssertEqual(frostflake.frostflakeDescription(),
                        "7319193677673271295 (2024-01-01 18:09:35 UTC, sequenceNumber:1, generatorIdentifier:2047)")
+    }
+
+    func testFrostflakeIdentifierBase58() {
+        let frostflakeFactory = Frostflake(generatorIdentifier: 987)
+
+        for _ in 0 ..< 10_000 {
+            let number: UInt64 = frostflakeFactory.generate()
+
+            let encoded = number.base58
+
+            if let decoded = UInt64(base58: encoded) {
+//                print("\(number) == \(encoded) == \(decoded)")
+                XCTAssertEqual(number, decoded)
+                XCTAssertEqual(encoded, decoded.base58)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description

Added support for base58 encoding.

## How Has This Been Tested?

Added unit tests, manual testing and benchmarks.

## Minimal checklist:

- [x] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [x] I have added unit and/or integration tests that prove my fix is effective or that my feature works
